### PR TITLE
ES7 -> ES2016.

### DIFF
--- a/exploring_async.md
+++ b/exploring_async.md
@@ -304,7 +304,7 @@ program.
 
 ## Async & Await
 
-Inspired by C#, the Async & Await is currently a proposal for the ES7
+Inspired by C#, the Async & Await is currently a proposal for the ES2016
 specification, and it's syntax is experimental. It might change upon final
 release. Nevertheless, it consists of the same idea of the Generator Coroutines method.
 Inside an function marked with the `async` keyword, you're able to `await` the


### PR DESCRIPTION
There will be no more ES7, it will be ES2016 (intention is to push browsers to implement new specs ASAP).
